### PR TITLE
Removes gyro inversion from 2023 bot

### DIFF
--- a/src/main/java/com/chaos131/swerve/BaseSwerveDrive.java
+++ b/src/main/java/com/chaos131/swerve/BaseSwerveDrive.java
@@ -264,7 +264,7 @@ public class BaseSwerveDrive extends SubsystemBase {
     if (RobotBase.isSimulation()) {
       return m_simrotation;
     }
-    return m_getRotation.get().times(-1);
+    return m_getRotation.get();
   }
 
   public Pose2d getPose() {


### PR DESCRIPTION
The NavX returns the Rotation2d in the direction we expect (CounterClockwise Positive), but this code was pulled from the 2023 bot where the NAVX was upside down and we had to use Clockwise Positive. 

Javadoc for getRotation2D for the AHRS class (NavX).:
![image](https://github.com/Manchester-Central/CHAOS-Shared-Code/assets/6991773/6b88995a-994e-432f-9576-6b4a37f1bd25)

We should not be doing this in the base class and allow the projects using this class to do it themselves.

For 2024/2022
```java
public SweveDrive2022(BaseSwerveModule[] modules, SwerveConfigs configs, AHRS gyro) {
  super(modules, configs, () -> gyro.getRotation2d());
}
```

For 2023
```java
public SweveDrive2023(BaseSwerveModule[] modules, SwerveConfigs configs, AHRS gyro) {
  super(modules, configs, () -> gyro.getRotation2d().times(-1));
}
```