### PR TITLE
Attempts to fix closed loop moving ramp period

### DIFF
--- a/src/main/java/com/chaos131/swerve/implementation/TalonFxAndCancoderSwerveModule.java
+++ b/src/main/java/com/chaos131/swerve/implementation/TalonFxAndCancoderSwerveModule.java
@@ -227,12 +227,14 @@ public class TalonFxAndCancoderSwerveModule extends BaseSwerveModule {
     @Override
     public void driverModeInit() {
         m_speedConfig.ClosedLoopRamps.DutyCycleClosedLoopRampPeriod = m_driveConfig.driverModeClosedLoopRampRatePeriod;
+        m_speedConfig.ClosedLoopRamps.VoltageClosedLoopRampPeriod = m_driveConfig.driverModeClosedLoopRampRatePeriod;
         m_speedController.getConfigurator().apply(m_speedConfig.ClosedLoopRamps);
     }
 
     @Override
     public void driveToPositionInit() {
         m_speedConfig.ClosedLoopRamps.DutyCycleClosedLoopRampPeriod = m_driveConfig.driveToPositionClosedLoopRampRatePeriod;
+        m_speedConfig.ClosedLoopRamps.VoltageClosedLoopRampPeriod = m_driveConfig.driveToPositionClosedLoopRampRatePeriod;
         m_speedController.getConfigurator().apply(m_speedConfig.ClosedLoopRamps);
     }
 


### PR DESCRIPTION
I'm wondering if we need to set `VoltageClosedLoopRampPeriod ` when using Voltage closed loop mode.

My thinking - `DutyCycleClosedLoopRampPeriod` and `VoltageClosedLoopRampPeriod` are basically the same thing (time to go from 0 to full power/voltage), so there wouldn't be a need for both until they were used exclusively by the different closed loop modes.

We can test this on Saturday.