### PR TITLE
Dashboard Unit

### DIFF
--- a/src/main/java/com/chaos131/util/DashboardUnit.java
+++ b/src/main/java/com/chaos131/util/DashboardUnit.java
@@ -23,9 +23,9 @@ public class DashboardUnit<T extends Unit> {
             name + "_" + m_defaultUnit.toString(), defaultValue.in(m_defaultUnit));
   }
 
-  // TODO: evaluate better way
   @SuppressWarnings("unchecked")
   public Measure<T> get() {
-    return (Measure<T>) m_defaultUnit.of(0);
+    return (Measure<T>) m_defaultUnit.of(m_networkNumber.get());
   }
+
 }

--- a/src/main/java/com/chaos131/util/DashboardUnit.java
+++ b/src/main/java/com/chaos131/util/DashboardUnit.java
@@ -1,0 +1,31 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package com.chaos131.util;
+
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.Unit;
+import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
+
+/**
+ * A utility for creating dashboard synced values in terms of units
+ */
+public class DashboardUnit<T extends Unit> {
+
+  protected LoggedNetworkNumber m_networkNumber;
+  protected T m_defaultUnit;
+
+  public DashboardUnit(String name, Measure<T> defaultValue) {
+    m_defaultUnit = defaultValue.unit();
+    m_networkNumber =
+        new LoggedNetworkNumber(
+            name + "_" + m_defaultUnit.toString(), defaultValue.in(m_defaultUnit));
+  }
+
+  // TODO: evaluate better way
+  @SuppressWarnings("unchecked")
+  public Measure<T> get() {
+    return (Measure<T>) m_defaultUnit.of(0);
+  }
+}


### PR DESCRIPTION
This adds a simple wrapper class around AdvantageKit's LoggedNetworkNumber (similar to our DashboardNumber) that creates a dashboard-synced number, but converts into a Measure with the default unit. 

```java
public DashboardUnit<DistanceUnit> m_questNavOffsetX = new DashboardUnit<>("QuestNavOffsetX", Inches.of(10));

// Gets DistanceUnit object
var offset = m_questNavOffsetX.get();

// Can now easily get the value in whatever unit we need
var offsetInches = offset.in(Inches);
var offsetMeters = offset.in(Meters);
```

It also adds the unit to the NetworkTables key automatically, so you can just call the key whatever and not worry about the unit (it will use the unit from the default value)
<img width="272" height="143" alt="image" src="https://github.com/user-attachments/assets/b894024c-04da-483e-8637-31c7d746064c" />
