### PR TITLE
Cleanup+improvements

### DIFF
--- a/release-config.json
+++ b/release-config.json
@@ -1,4 +1,4 @@
 {
     "major_version": 2026,
-    "minor_version": 0
+    "minor_version": 1
 }

--- a/src/main/java/com/chaos131/ctre/ChaosCanCoderTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosCanCoderTuner.java
@@ -60,7 +60,6 @@ public class ChaosCanCoderTuner {
         new DashboardNumber(
             "CANCoderConfig/" + m_name + "/" + valueName,
             initialValue,
-            true,
             false,
             newValue -> {
               onUpdate.accept(m_canCoder.Configuration, newValue);

--- a/src/main/java/com/chaos131/ctre/ChaosCanCoderTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosCanCoderTuner.java
@@ -58,7 +58,7 @@ public class ChaosCanCoderTuner {
       String valueName, double initialValue, BiConsumer<CANcoderConfiguration, Double> onUpdate) {
     DashboardNumber dsNumber =
         new DashboardNumber(
-            "CANCoderConfig/" + m_name + "/" + valueName,
+            m_name + "/" + valueName,
             initialValue,
             false,
             newValue -> {

--- a/src/main/java/com/chaos131/ctre/ChaosCanCoderTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosCanCoderTuner.java
@@ -29,12 +29,17 @@ public class ChaosCanCoderTuner {
     m_canCoder = canCoder;
   }
 
+  /** Creates tunables for the MagnetSensorConfigs number values using the cancoder's config */
+  public ChaosCanCoderTuner withMagnetSensor() {
+    return withMagnetSensor(m_canCoder.Configuration.MagnetSensor);
+  }
+
   /**
    * Creates tunables for the MagnetSensorConfigs number values
    *
    * @param initialConfig the starting MagnetSensorConfigs values
    */
-  public void tunableMagnetSensor(MagnetSensorConfigs initialConfig) {
+  public ChaosCanCoderTuner withMagnetSensor(MagnetSensorConfigs initialConfig) {
     tunable(
         "DiscontinuityPoint_rotations",
         initialConfig.AbsoluteSensorDiscontinuityPoint,
@@ -43,6 +48,7 @@ public class ChaosCanCoderTuner {
         "Offset_rotations",
         initialConfig.MagnetOffset,
         (config, newValue) -> config.MagnetSensor.MagnetOffset = newValue);
+    return this;
   }
 
   /**

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFx.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFx.java
@@ -11,6 +11,7 @@ import static edu.wpi.first.units.Units.Volts;
 import com.chaos131.can.CanConstants.CanBusName;
 import com.chaos131.can.CanConstants.CanId;
 import com.chaos131.pid.PIDFValue;
+import com.chaos131.util.PeriodicTasks;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.DynamicMotionMagicVoltage;
@@ -25,6 +26,7 @@ import com.ctre.phoenix6.sim.TalonFXSimState.MotorType;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Mass;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 
@@ -68,6 +70,10 @@ public class ChaosTalonFx extends TalonFX {
     var talonFXSim = this.getSimState();
     talonFXSim.Orientation = orientation;
     talonFXSim.setMotorType(motorType);
+
+    if (RobotBase.isSimulation()) {
+      PeriodicTasks.getInstance().addTask(this::simulationPeriodic);
+    }
   }
 
   /** Adds a CanCoder for syncing simulation values. */
@@ -75,6 +81,11 @@ public class ChaosTalonFx extends TalonFX {
     m_attachedCanCoder = canCoder;
   }
 
+  /**
+   * Sets the starting angle of the motor in the sim.
+   *
+   * @param simAngle the initial angle
+   */
   public void setSimAngle(Angle simAngle) {
     if (m_motorSimModel == null) {
       // Skip sim updates for motors without models
@@ -88,12 +99,7 @@ public class ChaosTalonFx extends TalonFX {
    * Tells the motor to handle updating the sim state. Copied/inspired from:
    * https://v6.docs.ctr-electronics.com/en/2024/docs/api-reference/simulation/simulation-intro.html
    */
-  public void simulationPeriodic() {
-    if (m_motorSimModel == null) {
-      // Skip sim updates for motors without models
-      return;
-    }
-
+  private void simulationPeriodic() {
     TalonFXSimState talonFxSim = getSimState();
 
     // set the supply voltage of the TalonFX

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxTuner.java
@@ -5,6 +5,8 @@
 package com.chaos131.ctre;
 
 import com.chaos131.util.DashboardNumber;
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.configs.FeedbackConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import java.util.ArrayList;
@@ -29,12 +31,17 @@ public class ChaosTalonFxTuner {
     m_talons = talons;
   }
 
+  /** Creates tunables for the Slot0 number values using the first motor's config */
+  public ChaosTalonFxTuner withSlot0() {
+    return withSlot0(m_talons[0].Configuration.Slot0);
+  }
+
   /**
    * Creates tunables for the Slot0 number values
    *
    * @param initialConfig the starting Slot0 values
    */
-  public void tunableSlot0(Slot0Configs initialConfig) {
+  public ChaosTalonFxTuner withSlot0(Slot0Configs initialConfig) {
     tunable("Slot0_kP", initialConfig.kP, (config, newValue) -> config.Slot0.kP = newValue);
     tunable("Slot0_kI", initialConfig.kI, (config, newValue) -> config.Slot0.kI = newValue);
     tunable("Slot0_kD", initialConfig.kD, (config, newValue) -> config.Slot0.kD = newValue);
@@ -42,6 +49,79 @@ public class ChaosTalonFxTuner {
     tunable("Slot0_kS", initialConfig.kS, (config, newValue) -> config.Slot0.kS = newValue);
     tunable("Slot0_kV", initialConfig.kV, (config, newValue) -> config.Slot0.kV = newValue);
     tunable("Slot0_kA", initialConfig.kA, (config, newValue) -> config.Slot0.kA = newValue);
+    return this;
+  }
+
+  /** Creates tunables for the CurrentLimitsConfigs number values using the first motor's config */
+  public ChaosTalonFxTuner withCurrentLimits() {
+    return withCurrentLimits(m_talons[0].Configuration.CurrentLimits);
+  }
+
+  /**
+   * Creates tunables for the CurrentLimitsConfigs number values
+   *
+   * @param initialConfig the starting CurrentLimitsConfigs values
+   */
+  public ChaosTalonFxTuner withCurrentLimits(CurrentLimitsConfigs initialConfig) {
+    tunable(
+        "CurrentLimit_Stator",
+        initialConfig.StatorCurrentLimit,
+        (config, newValue) -> config.CurrentLimits.StatorCurrentLimit = newValue);
+    tunable(
+        "CurrentLimit_Supply",
+        initialConfig.SupplyCurrentLimit,
+        (config, newValue) -> config.CurrentLimits.SupplyCurrentLimit = newValue);
+    tunable(
+        "CurrentLimit_SupplyLower_Limit",
+        initialConfig.SupplyCurrentLowerLimit,
+        (config, newValue) -> config.CurrentLimits.SupplyCurrentLowerLimit = newValue);
+    tunable(
+        "CurrentLimit_SupplyLower_Time",
+        initialConfig.SupplyCurrentLowerTime,
+        (config, newValue) -> config.CurrentLimits.SupplyCurrentLowerTime = newValue);
+    return this;
+  }
+
+  /** Creates tunables for the FeedbackConfigs number values using the first motor's config */
+  public ChaosTalonFxTuner withFeedbackValues() {
+    return withFeedbackValues(m_talons[0].Configuration.Feedback);
+  }
+
+  /**
+   * Creates tunables for the FeedbackConfigs number values
+   *
+   * @param initialConfig the starting FeedbackConfigs values
+   */
+  public ChaosTalonFxTuner withFeedbackValues(FeedbackConfigs initialConfig) {
+    tunable(
+        "Feedback_RotorToSensorRatio",
+        initialConfig.RotorToSensorRatio,
+        (config, newValue) -> config.Feedback.RotorToSensorRatio = newValue);
+    tunable(
+        "Feedback_SensorToMechanismRatio",
+        initialConfig.SensorToMechanismRatio,
+        (config, newValue) -> config.Feedback.SensorToMechanismRatio = newValue);
+    return this;
+  }
+
+  /**
+   * Adds all tunable values (currently Slot0, CurrentLimits, and FeedbackValues) using the first
+   * motor's config
+   */
+  public ChaosTalonFxTuner withAllConfigs() {
+    return withAllConfigs(m_talons[0].Configuration);
+  }
+
+  /**
+   * Adds all tunable values (currently Slot0, CurrentLimits, and FeedbackValues)
+   *
+   * @param initialConfig the starting config
+   */
+  public ChaosTalonFxTuner withAllConfigs(TalonFXConfiguration initialConfig) {
+    withSlot0(initialConfig.Slot0);
+    withCurrentLimits(initialConfig.CurrentLimits);
+    withFeedbackValues(initialConfig.Feedback);
+    return this;
   }
 
   /**

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxTuner.java
@@ -59,7 +59,6 @@ public class ChaosTalonFxTuner {
         new DashboardNumber(
             "TalonFxConfig/" + m_name + "/" + valueName,
             initialValue,
-            true,
             false,
             newValue -> {
               for (ChaosTalonFx chaosTalonFx : m_talons) {

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxTuner.java
@@ -57,7 +57,7 @@ public class ChaosTalonFxTuner {
       String valueName, double initialValue, BiConsumer<TalonFXConfiguration, Double> onUpdate) {
     DashboardNumber dsNumber =
         new DashboardNumber(
-            "TalonFxConfig/" + m_name + "/" + valueName,
+            m_name + "/" + valueName,
             initialValue,
             false,
             newValue -> {

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxs.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxs.java
@@ -10,6 +10,7 @@ import static edu.wpi.first.units.Units.Volts;
 import com.chaos131.can.CanConstants.CanBusName;
 import com.chaos131.can.CanConstants.CanId;
 import com.chaos131.pid.PIDFValue;
+import com.chaos131.util.PeriodicTasks;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXSConfiguration;
 import com.ctre.phoenix6.controls.DynamicMotionMagicVoltage;
@@ -20,6 +21,7 @@ import com.ctre.phoenix6.sim.CANcoderSimState;
 import com.ctre.phoenix6.sim.ChassisReference;
 import com.ctre.phoenix6.sim.TalonFXSSimState;
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 
@@ -60,6 +62,10 @@ public class ChaosTalonFxs extends TalonFXS {
     m_isMainSimMotor = isMainSimMotor;
     var talonFXSim = this.getSimState();
     talonFXSim.MotorOrientation = orientation;
+
+    if (RobotBase.isSimulation()) {
+      PeriodicTasks.getInstance().addTask(this::simulationPeriodic);
+    }
   }
 
   /** Adds a CanCoder for syncing simulation values. */
@@ -80,12 +86,7 @@ public class ChaosTalonFxs extends TalonFXS {
    * Tells the motor to handle updating the sim state. Copied/inspired from:
    * https://v6.docs.ctr-electronics.com/en/2024/docs/api-reference/simulation/simulation-intro.html
    */
-  public void simulationPeriodic() {
-    if (m_motorSimModel == null) {
-      // Skip sim updates for motors without models
-      return;
-    }
-
+  private void simulationPeriodic() {
     TalonFXSSimState talonFxSim = getSimState();
 
     // set the supply voltage of the TalonFX

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxsTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxsTuner.java
@@ -59,7 +59,6 @@ public class ChaosTalonFxsTuner {
         new DashboardNumber(
             "TalonFxConfig/" + m_name + "/" + valueName,
             initialValue,
-            true,
             false,
             newValue -> {
               for (ChaosTalonFxs chaosTalonFxs : m_talons) {

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxsTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxsTuner.java
@@ -57,7 +57,7 @@ public class ChaosTalonFxsTuner {
       String valueName, double initialValue, BiConsumer<TalonFXSConfiguration, Double> onUpdate) {
     DashboardNumber dsNumber =
         new DashboardNumber(
-            "TalonFxConfig/" + m_name + "/" + valueName,
+            m_name + "/" + valueName,
             initialValue,
             false,
             newValue -> {

--- a/src/main/java/com/chaos131/ctre/ChaosTalonFxsTuner.java
+++ b/src/main/java/com/chaos131/ctre/ChaosTalonFxsTuner.java
@@ -5,6 +5,8 @@
 package com.chaos131.ctre;
 
 import com.chaos131.util.DashboardNumber;
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.configs.ExternalFeedbackConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXSConfiguration;
 import java.util.ArrayList;
@@ -29,12 +31,17 @@ public class ChaosTalonFxsTuner {
     m_talons = talons;
   }
 
+  /** Creates tunables for the Slot0 number values using the first motor's config */
+  public ChaosTalonFxsTuner withSlot0() {
+    return withSlot0(m_talons[0].Configuration.Slot0);
+  }
+
   /**
    * Creates tunables for the Slot0 number values
    *
    * @param initialConfig the starting Slot0 values
    */
-  public void tunableSlot0(Slot0Configs initialConfig) {
+  public ChaosTalonFxsTuner withSlot0(Slot0Configs initialConfig) {
     tunable("Slot0_kP", initialConfig.kP, (config, newValue) -> config.Slot0.kP = newValue);
     tunable("Slot0_kI", initialConfig.kI, (config, newValue) -> config.Slot0.kI = newValue);
     tunable("Slot0_kD", initialConfig.kD, (config, newValue) -> config.Slot0.kD = newValue);
@@ -42,6 +49,81 @@ public class ChaosTalonFxsTuner {
     tunable("Slot0_kS", initialConfig.kS, (config, newValue) -> config.Slot0.kS = newValue);
     tunable("Slot0_kV", initialConfig.kV, (config, newValue) -> config.Slot0.kV = newValue);
     tunable("Slot0_kA", initialConfig.kA, (config, newValue) -> config.Slot0.kA = newValue);
+    return this;
+  }
+
+  /** Creates tunables for the CurrentLimitsConfigs number values using the first motor's config */
+  public ChaosTalonFxsTuner withCurrentLimits() {
+    return withCurrentLimits(m_talons[0].Configuration.CurrentLimits);
+  }
+
+  /**
+   * Creates tunables for the CurrentLimitsConfigs number values
+   *
+   * @param initialConfig the starting CurrentLimitsConfigs values
+   */
+  public ChaosTalonFxsTuner withCurrentLimits(CurrentLimitsConfigs initialConfig) {
+    tunable(
+        "CurrentLimit_Stator",
+        initialConfig.StatorCurrentLimit,
+        (config, newValue) -> config.CurrentLimits.StatorCurrentLimit = newValue);
+    tunable(
+        "CurrentLimit_Supply",
+        initialConfig.SupplyCurrentLimit,
+        (config, newValue) -> config.CurrentLimits.SupplyCurrentLimit = newValue);
+    tunable(
+        "CurrentLimit_SupplyLower_Limit",
+        initialConfig.SupplyCurrentLowerLimit,
+        (config, newValue) -> config.CurrentLimits.SupplyCurrentLowerLimit = newValue);
+    tunable(
+        "CurrentLimit_SupplyLower_Time",
+        initialConfig.SupplyCurrentLowerTime,
+        (config, newValue) -> config.CurrentLimits.SupplyCurrentLowerTime = newValue);
+    return this;
+  }
+
+  /**
+   * Creates tunables for the ExternalFeedbackConfigs number values using the first motor's config
+   */
+  public ChaosTalonFxsTuner withFeedbackValues() {
+    return withFeedbackValues(m_talons[0].Configuration.ExternalFeedback);
+  }
+
+  /**
+   * Creates tunables for the ExternalFeedbackConfigs number values
+   *
+   * @param initialConfig the starting ExternalFeedbackConfigs values
+   */
+  public ChaosTalonFxsTuner withFeedbackValues(ExternalFeedbackConfigs initialConfig) {
+    tunable(
+        "Feedback_RotorToSensorRatio",
+        initialConfig.RotorToSensorRatio,
+        (config, newValue) -> config.ExternalFeedback.RotorToSensorRatio = newValue);
+    tunable(
+        "Feedback_SensorToMechanismRatio",
+        initialConfig.SensorToMechanismRatio,
+        (config, newValue) -> config.ExternalFeedback.SensorToMechanismRatio = newValue);
+    return this;
+  }
+
+  /**
+   * Adds all tunable values (currently Slot0, CurrentLimits, and FeedbackValues) using the first
+   * motor's config
+   */
+  public ChaosTalonFxsTuner withAllConfigs() {
+    return withAllConfigs(m_talons[0].Configuration);
+  }
+
+  /**
+   * Adds all tunable values (currently Slot0, CurrentLimits, and FeedbackValues)
+   *
+   * @param initialConfig the starting config
+   */
+  public ChaosTalonFxsTuner withAllConfigs(TalonFXSConfiguration initialConfig) {
+    withSlot0(initialConfig.Slot0);
+    withCurrentLimits(initialConfig.CurrentLimits);
+    withFeedbackValues(initialConfig.ExternalFeedback);
+    return this;
   }
 
   /**

--- a/src/main/java/com/chaos131/pid/LoggedPIDTuner.java
+++ b/src/main/java/com/chaos131/pid/LoggedPIDTuner.java
@@ -7,7 +7,9 @@ import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
  * A Logged Dashboard number specific for PID Values. This is useful for tracking PID values during
  * testing, but should be replaced with a basic PID structure once settled. Extends the PIDTuner to
  * make it easier to swap between the two.
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
  */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class LoggedPIDTuner extends PIDTuner {
   /** The P, I, D, and F values broken into their own logged values */
   private LoggedNetworkNumber m_p, m_i, m_d, m_f;

--- a/src/main/java/com/chaos131/pid/LoggedPIDTuner.java
+++ b/src/main/java/com/chaos131/pid/LoggedPIDTuner.java
@@ -7,7 +7,9 @@ import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
  * A Logged Dashboard number specific for PID Values. This is useful for tracking PID values during
  * testing, but should be replaced with a basic PID structure once settled. Extends the PIDTuner to
  * make it easier to swap between the two.
- * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
+ *
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's
+ *     PIDController already supports dashboard tuning.
  */
 @Deprecated(since = "2026.1", forRemoval = true)
 public class LoggedPIDTuner extends PIDTuner {

--- a/src/main/java/com/chaos131/pid/PIDFValue.java
+++ b/src/main/java/com/chaos131/pid/PIDFValue.java
@@ -6,7 +6,9 @@ package com.chaos131.pid;
 
 /**
  * A PIDF update value.
- * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
+ *
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's
+ *     PIDController already supports dashboard tuning.
  */
 @Deprecated(since = "2026.1", forRemoval = true)
 public class PIDFValue {

--- a/src/main/java/com/chaos131/pid/PIDFValue.java
+++ b/src/main/java/com/chaos131/pid/PIDFValue.java
@@ -4,6 +4,11 @@
 
 package com.chaos131.pid;
 
+/**
+ * A PIDF update value.
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
+ */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class PIDFValue {
   public final double P, I, D, F;
 

--- a/src/main/java/com/chaos131/pid/PIDTuner.java
+++ b/src/main/java/com/chaos131/pid/PIDTuner.java
@@ -8,7 +8,10 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import java.util.function.Consumer;
 
-/** Helps tune a PID from the Dashboard */
+/** Helps tune a PID from the Dashboard
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
+*/
+@Deprecated(since = "2026.1", forRemoval = true)
 public class PIDTuner {
   protected final String m_componentName;
   protected final boolean m_tuningEnabled;

--- a/src/main/java/com/chaos131/pid/PIDTuner.java
+++ b/src/main/java/com/chaos131/pid/PIDTuner.java
@@ -8,9 +8,12 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import java.util.function.Consumer;
 
-/** Helps tune a PID from the Dashboard
- * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
-*/
+/**
+ * Helps tune a PID from the Dashboard
+ *
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's
+ *     PIDController already supports dashboard tuning.
+ */
 @Deprecated(since = "2026.1", forRemoval = true)
 public class PIDTuner {
   protected final String m_componentName;

--- a/src/main/java/com/chaos131/pid/PIDValue.java
+++ b/src/main/java/com/chaos131/pid/PIDValue.java
@@ -4,6 +4,11 @@
 
 package com.chaos131.pid;
 
+/**
+ * A PID update value.
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
+ */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class PIDValue {
   public final double P, I, D;
 

--- a/src/main/java/com/chaos131/pid/PIDValue.java
+++ b/src/main/java/com/chaos131/pid/PIDValue.java
@@ -6,7 +6,9 @@ package com.chaos131.pid;
 
 /**
  * A PID update value.
- * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's PIDController already supports dashboard tuning.
+ *
+ * @deprecated We use {@link com.chaos131.ctre.ChaosTalonFxTuner} for CTRE PID tuning and WPILib's
+ *     PIDController already supports dashboard tuning.
  */
 @Deprecated(since = "2026.1", forRemoval = true)
 public class PIDValue {

--- a/src/main/java/com/chaos131/robot/ChaosRobot.java
+++ b/src/main/java/com/chaos131/robot/ChaosRobot.java
@@ -17,7 +17,12 @@ import org.littletonrobotics.junction.wpilog.WPILOGWriter.AdvantageScopeOpenBeha
 /**
  * A ChaosRobot architecture that bundles together common libraries like AdvantageKit, PathPlanner,
  * and common features like mode timers.
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
  */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class ChaosRobot<
         TSwerveDrive extends BaseSwerveDrive,
         TChaosRobotContainer extends ChaosRobotContainer<TSwerveDrive>>

--- a/src/main/java/com/chaos131/robot/ChaosRobotContainer.java
+++ b/src/main/java/com/chaos131/robot/ChaosRobotContainer.java
@@ -12,7 +12,12 @@ import edu.wpi.first.wpilibj2.command.Command;
 /**
  * Base robot container that accompanies ChaosRobot, and contains many data structures and methods
  * that are common across seasons and projects.
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
  */
+@Deprecated(since = "2026.1", forRemoval = true)
 public abstract class ChaosRobotContainer<TSwerveDrive extends BaseSwerveDrive> {
   /** Default Constructor, initializes AutoChoices, Controller Setups */
   public ChaosRobotContainer() {

--- a/src/main/java/com/chaos131/swerve/BaseSwerveDrive.java
+++ b/src/main/java/com/chaos131/swerve/BaseSwerveDrive.java
@@ -36,7 +36,14 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.littletonrobotics.junction.AutoLog;
 
-/** The larger SwerveDrive subsystem that manages each swerve module. */
+/**
+ * The larger SwerveDrive subsystem that manages each swerve module.
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
+ */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class BaseSwerveDrive extends SubsystemBase {
   /** Tracks the state of the swerve system in AdvantageKit */
   @AutoLog

--- a/src/main/java/com/chaos131/swerve/BaseSwerveModule.java
+++ b/src/main/java/com/chaos131/swerve/BaseSwerveModule.java
@@ -17,7 +17,12 @@ import org.littletonrobotics.junction.Logger;
 /**
  * An individual swerve module that composes the swerve drive system. There are typically 4 modules
  * on a robot.
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
  */
+@Deprecated(since = "2026.1", forRemoval = true)
 public abstract class BaseSwerveModule {
 
   /** Name of the swerve module, typically this is FrontLeft, FrontRight, etc */

--- a/src/main/java/com/chaos131/swerve/ModuleState.java
+++ b/src/main/java/com/chaos131/swerve/ModuleState.java
@@ -9,8 +9,13 @@ import org.littletonrobotics.junction.AutoLog;
  *
  * <p>Note that this is separated from the BaseSwerveModule's scope because java does not like the
  * nesting of the derived ModuleStateAutoLogged within an abstract BaseSwerveModule class.
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
  */
 @AutoLog
+@Deprecated(since = "2026.1", forRemoval = true)
 public class ModuleState {
   /** Tracks if the motor is active and responsive */
   public boolean driveMotorConnected = true;

--- a/src/main/java/com/chaos131/swerve/SwerveConfigs.java
+++ b/src/main/java/com/chaos131/swerve/SwerveConfigs.java
@@ -11,7 +11,12 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 /**
  * Configuration container that holds debug states, PID values, tolerance values, and any other
  * Swerve Tuning values.
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
  */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class SwerveConfigs {
   /** These configs should be created and configured before creating the swerve drive class */
   public SwerveConfigs() {}

--- a/src/main/java/com/chaos131/swerve/implementation/TalonFxAndCancoderSwerveModule.java
+++ b/src/main/java/com/chaos131/swerve/implementation/TalonFxAndCancoderSwerveModule.java
@@ -24,9 +24,15 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 /**
  * Creates a Swerve Module using TalonFxs and a CANcoder (CHAOS's 2022 and 2024 bots used this
  * configuration)
+ *
+ * @deprecated CHAOS has moved onto using <a
+ *     href="https://docs.advantagekit.org/getting-started/template-projects/talonfx-swerve-template/">AdvantageKit's
+ *     TalonFx template</a>
  */
+@Deprecated(since = "2026.1", forRemoval = true)
 public class TalonFxAndCancoderSwerveModule extends BaseSwerveModule {
 
+  @Deprecated(since = "2026.1", forRemoval = true)
   public static class SpeedControllerConfig {
     public final int canId;
     public final InvertedValue motorDirection;
@@ -42,6 +48,7 @@ public class TalonFxAndCancoderSwerveModule extends BaseSwerveModule {
     }
   }
 
+  @Deprecated(since = "2026.1", forRemoval = true)
   public static class AngleControllerConfig {
     public final int canId;
     public final InvertedValue motorDirection;
@@ -54,6 +61,7 @@ public class TalonFxAndCancoderSwerveModule extends BaseSwerveModule {
     }
   }
 
+  @Deprecated(since = "2026.1", forRemoval = true)
   public static class AbsoluteEncoderConfig {
     public final int canId;
     public final SensorDirectionValue sensorDirection;
@@ -67,6 +75,7 @@ public class TalonFxAndCancoderSwerveModule extends BaseSwerveModule {
     }
   }
 
+  @Deprecated(since = "2026.1", forRemoval = true)
   public static class DriveConfig {
     public final double driverModeClosedLoopRampRatePeriod;
     public final double driveToPositionClosedLoopRampRatePeriod;

--- a/src/main/java/com/chaos131/util/DashboardNumber.java
+++ b/src/main/java/com/chaos131/util/DashboardNumber.java
@@ -34,6 +34,11 @@ public class DashboardNumber {
   /** What to do when the number is changed */
   private Consumer<Double> m_onUpdate;
 
+  /** Adds a task to periodically check all dashboard numbers */
+  static {
+    PeriodicTasks.getInstance().addTask(DashboardNumber::checkAll);
+  }
+
   /**
    * Creates a value that can be updated via NetworkTables.
    *
@@ -98,7 +103,7 @@ public class DashboardNumber {
   }
 
   /** Checks every Dashboard number and updates them if they need to be updated */
-  public static void checkAll() {
+  private static void checkAll() {
     for (DashboardNumber dashboardNumber : AllUpdaters) {
       dashboardNumber.checkValue();
     }

--- a/src/main/java/com/chaos131/util/DashboardNumber.java
+++ b/src/main/java/com/chaos131/util/DashboardNumber.java
@@ -30,8 +30,15 @@ public class DashboardNumber {
   /** What to do when the number is changed */
   private Consumer<Double> m_onUpdate;
 
-  /** checks if the tuning is enabled...? */
-  private boolean m_tuningEnabled;
+  /**
+   * Creates a value that can be updated via NetworkTables.
+   *
+   * @param name of the field in network tables
+   * @param startValue the initial value to be used
+   */
+  public DashboardNumber(String name, double startValue) {
+    this(name, startValue, false, (value) -> {});
+  }
 
   /**
    * Creates a value that can be updated via NetworkTables. Note: `onUpdate` will be immediately
@@ -39,12 +46,10 @@ public class DashboardNumber {
    *
    * @param name of the field in network tables
    * @param startValue the initial value to be used
-   * @param tuningEnabled if tuning is enabled
    * @param onUpdate what to do when the value changes
    */
-  public DashboardNumber(
-      String name, double startValue, boolean tuningEnabled, Consumer<Double> onUpdate) {
-    this(name, startValue, tuningEnabled, true, onUpdate);
+  public DashboardNumber(String name, double startValue, Consumer<Double> onUpdate) {
+    this(name, startValue, true, onUpdate);
   }
 
   /**
@@ -52,7 +57,6 @@ public class DashboardNumber {
    *
    * @param name of the field in network tables
    * @param startValue the initial value to be used
-   * @param tuningEnabled if tuning is enabled
    * @param willTriggerWithInitialValue if true, `onUpdate` will be immediately called with
    *     `initialValue`
    * @param onUpdate what to do when the value changes
@@ -60,19 +64,15 @@ public class DashboardNumber {
   public DashboardNumber(
       String name,
       double startValue,
-      boolean tuningEnabled,
       boolean willTriggerWithInitialValue,
       Consumer<Double> onUpdate) {
     m_value = startValue;
     m_name = name;
     m_onUpdate = onUpdate;
-    m_tuningEnabled = tuningEnabled;
     if (willTriggerWithInitialValue) {
       onUpdate.accept(m_value);
     }
-    if (m_tuningEnabled) {
-      SmartDashboard.putNumber(name, m_value);
-    }
+    SmartDashboard.putNumber(name, m_value);
     AllUpdaters.add(this);
   }
 
@@ -85,9 +85,6 @@ public class DashboardNumber {
 
   /** Check if the value is new, run the update function if it is */
   private void checkValue() {
-    if (!m_tuningEnabled) {
-      return;
-    }
     var newValue = SmartDashboard.getNumber(m_name, m_value);
     if (newValue != m_value) {
       m_value = newValue;

--- a/src/main/java/com/chaos131/util/DashboardUnit.java
+++ b/src/main/java/com/chaos131/util/DashboardUnit.java
@@ -6,23 +6,67 @@ package com.chaos131.util;
 
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Unit;
-import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
+import java.util.function.Consumer;
 
 /** A utility for creating dashboard synced values in terms of units */
 public class DashboardUnit<U extends Unit, M extends Measure<U>> {
 
-  protected LoggedNetworkNumber m_networkNumber;
+  /** The DashboardNumber used for getting updates to/from the NetworkTables. */
+  protected DashboardNumber m_dsNumber;
+
+  /**
+   * The default unit the DashboardUnit was created with. The Dashboard number with be displayed
+   * with this unit.
+   */
   protected U m_defaultUnit;
 
-  public DashboardUnit(String name, M defaultValue) {
+  /** What to do when the number is changed */
+  protected Consumer<M> m_onUpdate;
+
+  /**
+   * Creates a measure that can be updated on the Dashboard
+   *
+   * @param name The name for this value on the Dashboard
+   * @param defaultValue The default value to be displayed
+   * @param willTriggerWithInitialValue if true, `onUpdate` will be immediately called with
+   *     `initialValue`
+   * @param onUpdate The consumer that will be called when the value is updated
+   */
+  public DashboardUnit(
+      String name, M defaultValue, boolean willTriggerWithInitialValue, Consumer<M> onUpdate) {
     m_defaultUnit = defaultValue.unit();
-    m_networkNumber =
-        new LoggedNetworkNumber(
-            name + "_" + m_defaultUnit.toString(), defaultValue.in(m_defaultUnit));
+    m_onUpdate = onUpdate;
+    m_dsNumber =
+        new DashboardNumber(
+            name + "_" + m_defaultUnit.toString(),
+            defaultValue.in(m_defaultUnit),
+            willTriggerWithInitialValue,
+            (value) -> m_onUpdate.accept(convertDoubleToMeasure(value)));
   }
 
-  @SuppressWarnings("unchecked")
+  /**
+   * Creates a measure that can be updated on the Dashboard
+   *
+   * @param name The name for this value on the Dashboard
+   * @param defaultValue The default value to be displayed
+   */
+  public DashboardUnit(String name, M defaultValue) {
+    this(name, defaultValue, false, (value) -> {});
+  }
+
+  /** Get the current value of the Measure. */
   public M get() {
-    return (M) m_defaultUnit.of(m_networkNumber.get());
+    return convertDoubleToMeasure(m_dsNumber.get());
+  }
+
+  /**
+   * Converts a double value into a measure with the default unit. Note: Java warnings are disabled
+   * because the compiler cannot safely cast from Measure<?> to M, but we know it's safe.
+   *
+   * @param value The value to convert to a measure
+   */
+  @SuppressWarnings("unchecked")
+  private M convertDoubleToMeasure(double value) {
+    return (M) m_defaultUnit.of(value);
   }
 }

--- a/src/main/java/com/chaos131/util/PeriodicTasks.java
+++ b/src/main/java/com/chaos131/util/PeriodicTasks.java
@@ -1,0 +1,48 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package com.chaos131.util;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is a class designed to add automatic periodic processing of tasks, like checking for dashboard number updates.
+ */
+public final class PeriodicTasks extends SubsystemBase {
+
+  /**
+   * The singleton instance of the subsystem.
+   */
+  private static PeriodicTasks m_instance = new PeriodicTasks();
+
+  /**
+   * Gets the singleton instance of the subsystem
+   * @return
+   */
+  public static PeriodicTasks getInstance() {
+    return m_instance;
+  }
+
+  /**
+   * The list of the tasks to run.
+   */
+  private List<Runnable> m_tasks = new ArrayList<>();
+
+  /** Creates a new PeriodicTasks. Private to force user of getInstance */
+  private PeriodicTasks() {}
+
+  /**
+   * Adds a new task to be processed periodically.
+   */
+  public void addTask(Runnable task) {
+    m_tasks.add(task);
+  }
+
+  @Override
+  public void periodic() {
+    m_tasks.forEach(r -> r.run());
+  }
+}

--- a/src/main/java/com/chaos131/util/PeriodicTasks.java
+++ b/src/main/java/com/chaos131/util/PeriodicTasks.java
@@ -9,34 +9,28 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This is a class designed to add automatic periodic processing of tasks, like checking for dashboard number updates.
+ * This is a class designed to add automatic periodic processing of tasks, like checking for
+ * dashboard number updates.
  */
 public final class PeriodicTasks extends SubsystemBase {
 
-  /**
-   * The singleton instance of the subsystem.
-   */
+  /** The singleton instance of the subsystem. */
   private static PeriodicTasks m_instance = new PeriodicTasks();
 
   /**
    * Gets the singleton instance of the subsystem
-   * @return
    */
   public static PeriodicTasks getInstance() {
     return m_instance;
   }
 
-  /**
-   * The list of the tasks to run.
-   */
+  /** The list of the tasks to run. */
   private List<Runnable> m_tasks = new ArrayList<>();
 
   /** Creates a new PeriodicTasks. Private to force user of getInstance */
   private PeriodicTasks() {}
 
-  /**
-   * Adds a new task to be processed periodically.
-   */
+  /** Adds a new task to be processed periodically. */
   public void addTask(Runnable task) {
     m_tasks.add(task);
   }

--- a/src/main/java/com/chaos131/util/PeriodicTasks.java
+++ b/src/main/java/com/chaos131/util/PeriodicTasks.java
@@ -17,9 +17,7 @@ public final class PeriodicTasks extends SubsystemBase {
   /** The singleton instance of the subsystem. */
   private static PeriodicTasks m_instance = new PeriodicTasks();
 
-  /**
-   * Gets the singleton instance of the subsystem
-   */
+  /** Gets the singleton instance of the subsystem */
   public static PeriodicTasks getInstance() {
     return m_instance;
   }


### PR DESCRIPTION

### Changes
A lot of minor changes in here:

#### Deprecated logic related to BaseSwerveDrive and PIDTuners
Since we are using AdvantageKit's TalonFx Template, we don't need to maintain our old swerve drive code (hopefully) and we have no need for PIDTuner anymore

#### DashboardNumber & Unit
* Updated constructors for DashboardNumber to be more friendly
* DashboardNumber now uses AdvantageKit's LoggedNetworkNumber so values will be around for replay
* All values changed now are displayed in a "Changed DashboardNumbers" alert type, which is viewable in Dashboards and AdvantageScope
* CheckAll no longer needs to be called manually in the 2026 project - now handled by a PeriodTasks subsystem
* DashboardUnit now uses DashboardNumber to get a lot of features associated with it (like callbacks and alerts)

#### CTRE Helpers
* ChaosTalonFxs sims now updated automatically via PeriodicTasks (i.e., simulationPeriodic doesn't need to be called manually in the 2026 subsystems)
* Tuners now have more default tunables that can be added via builder methods


#### Screenshot showing off DashboardNumber Alerts and more tunables:
<img width="1771" height="1128" alt="image" src="https://github.com/user-attachments/assets/1f63ad10-3309-48cd-8f15-de2b1e1ef7f0" />
