### PR TITLE
Lookup fixes

### DIFF
--- a/src/main/java/com/chaos131/tables/LookupTable.java
+++ b/src/main/java/com/chaos131/tables/LookupTable.java
@@ -71,14 +71,14 @@ public abstract class LookupTable<
       return lastEntry;
     }
 
-    var lowerRow =
+    var highRow =
         m_data.stream()
-            .filter(row -> row.getMeasure().lte(measure))
+            .filter(row -> row.getMeasure().gt(measure))
             .findFirst()
             .get(); // TODO: check logic
-    var lowerRowIndex = m_data.indexOf(lowerRow);
-    var higherRow = m_data.get(lowerRowIndex + 1);
-    return mergeRows(measure, lowerRow, higherRow);
+    var highRowIndex = m_data.indexOf(highRow);
+    var lowRow = m_data.get(highRowIndex - 1);
+    return mergeRows(measure, lowRow, highRow);
   }
 
   /**

--- a/src/main/java/com/chaos131/tables/LookupTable.java
+++ b/src/main/java/com/chaos131/tables/LookupTable.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
  */
 public abstract class LookupTable<
     U extends Unit, M extends Measure<U>, TR extends ITableRow<U, M>> {
-  private List<TR> m_data = new ArrayList<>();
+  private List<TR> m_data;
   private Comparator<TR> m_comparator =
       new Comparator<TR>() {
         public int compare(TR row1, TR row2) {
@@ -25,6 +25,14 @@ public abstract class LookupTable<
         }
       };
 
+  public LookupTable() {
+    m_data = new ArrayList<>();
+  }
+
+  public LookupTable(List<TR> rows) {
+    m_data = new ArrayList<>(rows);
+  }
+  
   /**
    * Adds a row to the lookup table
    *

--- a/src/main/java/com/chaos131/tables/LookupTable.java
+++ b/src/main/java/com/chaos131/tables/LookupTable.java
@@ -110,5 +110,5 @@ public abstract class LookupTable<
    * @param row1 one row
    * @param row2 the other row
    */
-  abstract TR mergeRows(M targetMeasure, TR row1, TR row2);
+  public abstract TR mergeRows(M targetMeasure, TR row1, TR row2);
 }

--- a/src/main/java/com/chaos131/tables/LookupTable.java
+++ b/src/main/java/com/chaos131/tables/LookupTable.java
@@ -32,7 +32,7 @@ public abstract class LookupTable<
   public LookupTable(List<TR> rows) {
     m_data = new ArrayList<>(rows);
   }
-  
+
   /**
    * Adds a row to the lookup table
    *

--- a/src/test/java/com/chaos131/tables/LookupTableTests.java
+++ b/src/test/java/com/chaos131/tables/LookupTableTests.java
@@ -4,13 +4,15 @@ import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import edu.wpi.first.units.DistanceUnit;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearVelocity;
-import java.util.List;
-import java.util.function.Function;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class LookupTableTests {
 
@@ -124,7 +126,7 @@ public class LookupTableTests {
 
     assertEquals(
         0, getLookupSpeed.apply(Meters.of(10))); // If exact value, expect exact value (high)
-    assertEquals(50, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect same value
+    assertEquals(50, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect interpolated value
   }
 
   @Test
@@ -141,8 +143,8 @@ public class LookupTableTests {
     Function<Distance, Double> getLookupSpeed =
         (Distance d) -> table.performLookup(d).m_launchSpeed.in(MetersPerSecond);
 
-    assertEquals(5, getLookupSpeed.apply(Meters.of(2))); // If inbetween value, expect same value
-    assertEquals(15, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect same value
-    assertEquals(60, getLookupSpeed.apply(Meters.of(8))); // If inbetween value, expect same value
+    assertEquals(5, getLookupSpeed.apply(Meters.of(2))); // If inbetween values, expect interpolated value
+    assertEquals(15, getLookupSpeed.apply(Meters.of(5))); // If inbetween values, expect interpolated value
+    assertEquals(60, getLookupSpeed.apply(Meters.of(8))); // If inbetween values, expect interpolated value
   }
 }

--- a/src/test/java/com/chaos131/tables/LookupTableTests.java
+++ b/src/test/java/com/chaos131/tables/LookupTableTests.java
@@ -4,15 +4,13 @@ import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.function.Function;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import edu.wpi.first.units.DistanceUnit;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearVelocity;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LookupTableTests {
 
@@ -126,7 +124,8 @@ public class LookupTableTests {
 
     assertEquals(
         0, getLookupSpeed.apply(Meters.of(10))); // If exact value, expect exact value (high)
-    assertEquals(50, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect interpolated value
+    assertEquals(
+        50, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect interpolated value
   }
 
   @Test
@@ -143,8 +142,11 @@ public class LookupTableTests {
     Function<Distance, Double> getLookupSpeed =
         (Distance d) -> table.performLookup(d).m_launchSpeed.in(MetersPerSecond);
 
-    assertEquals(5, getLookupSpeed.apply(Meters.of(2))); // If inbetween values, expect interpolated value
-    assertEquals(15, getLookupSpeed.apply(Meters.of(5))); // If inbetween values, expect interpolated value
-    assertEquals(60, getLookupSpeed.apply(Meters.of(8))); // If inbetween values, expect interpolated value
+    assertEquals(
+        5, getLookupSpeed.apply(Meters.of(2))); // If inbetween values, expect interpolated value
+    assertEquals(
+        15, getLookupSpeed.apply(Meters.of(5))); // If inbetween values, expect interpolated value
+    assertEquals(
+        60, getLookupSpeed.apply(Meters.of(8))); // If inbetween values, expect interpolated value
   }
 }

--- a/src/test/java/com/chaos131/tables/LookupTableTests.java
+++ b/src/test/java/com/chaos131/tables/LookupTableTests.java
@@ -126,4 +126,23 @@ public class LookupTableTests {
         0, getLookupSpeed.apply(Meters.of(10))); // If exact value, expect exact value (high)
     assertEquals(50, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect same value
   }
+
+  @Test
+  public void testLookupTableManyRows() {
+    var table =
+        new FakeLookupTable()
+            .addRows(
+                List.of(
+                    new FakeTableRow(Meters.of(0), MetersPerSecond.of(0)),
+                    new FakeTableRow(Meters.of(4), MetersPerSecond.of(10)),
+                    new FakeTableRow(Meters.of(6), MetersPerSecond.of(20)),
+                    new FakeTableRow(Meters.of(10), MetersPerSecond.of(100))));
+
+    Function<Distance, Double> getLookupSpeed =
+        (Distance d) -> table.performLookup(d).m_launchSpeed.in(MetersPerSecond);
+
+    assertEquals(5, getLookupSpeed.apply(Meters.of(2))); // If inbetween value, expect same value
+    assertEquals(15, getLookupSpeed.apply(Meters.of(5))); // If inbetween value, expect same value
+    assertEquals(60, getLookupSpeed.apply(Meters.of(8))); // If inbetween value, expect same value
+  }
 }


### PR DESCRIPTION
I was grabbing the wrong rows to interpolate between. 

Didn't notice until I was testing this table and found that at 2.9m, I was getting a value of 39+ because it was interpolating (or rather extrapolating) using the 1m and 2m data rows
<img width="1538" height="201" alt="image" src="https://github.com/user-attachments/assets/9040650f-a679-4bda-88d6-99c53e623c51" />

Adds more tests so we don't miss it in the future